### PR TITLE
Add adjustment of log start date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "logviewer-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "eframe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "logviewer-rs"
 description = "Log viewer app for viewing plots of data from projects such as motor and generator control"
 authors = ["SkyTEM Surveys", "Marc Beck König"]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 repository = "https://github.com/luftkode/logviewer-rs"
 homepage = "https://github.com/luftkode/logviewer-rs"

--- a/crates/log_if/src/lib.rs
+++ b/crates/log_if/src/lib.rs
@@ -11,6 +11,8 @@ pub trait Plotable {
     fn raw_plots(&self) -> &[RawPlot];
     /// Return the first timestamp, meaning the timestamp of the first entry
     fn first_timestamp(&self) -> DateTime<Utc>;
+    /// A name that uniquely identifies the type of log
+    fn unique_name(&self) -> &str;
 }
 
 /// A given log should implement this trait

--- a/crates/plot_util/src/lib.rs
+++ b/crates/plot_util/src/lib.rs
@@ -9,11 +9,16 @@ use serde::{Deserialize, Serialize};
 pub struct PlotWithName {
     pub raw_plot: Vec<[f64; 2]>,
     pub name: String,
+    pub log_id: String,
 }
 
 impl PlotWithName {
-    pub fn new(raw_plot: Vec<[f64; 2]>, name: String) -> Self {
-        Self { raw_plot, name }
+    pub fn new(raw_plot: Vec<[f64; 2]>, name: String, id: String) -> Self {
+        Self {
+            raw_plot,
+            name,
+            log_id: id,
+        }
     }
 }
 

--- a/crates/skytem_logs/src/generator.rs
+++ b/crates/skytem_logs/src/generator.rs
@@ -101,6 +101,10 @@ impl Plotable for GeneratorLog {
             .timestamp
             .and_utc()
     }
+
+    fn unique_name(&self) -> &str {
+        "Legacy Generator Log 2016"
+    }
 }
 
 // Helper function to keep all the boiler plate of building each plot

--- a/crates/skytem_logs/src/mbed_motor_control/pid.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/pid.rs
@@ -96,6 +96,10 @@ impl Plotable for PidLog {
     fn first_timestamp(&self) -> chrono::DateTime<chrono::Utc> {
         chrono::DateTime::default()
     }
+
+    fn unique_name(&self) -> &str {
+        "Mbed PID log 2024"
+    }
 }
 
 impl fmt::Display for PidLog {

--- a/crates/skytem_logs/src/mbed_motor_control/status.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/status.rs
@@ -107,6 +107,21 @@ impl Plotable for StatusLog {
 }
 
 impl StatusLog {
+    /// If we don't match up with other plot points it is because the date was offset so we need to apply the offset here as well
+    pub fn update_timestamp_with_state_changes(&mut self) {
+        if let Some((timestamp, _)) = self.timestamps_with_state_changes.first_mut() {
+            if let Some(first_entry) = self.entries.first() {
+                let first_entry_timestamp = first_entry.timestamp_ns();
+                if first_entry_timestamp != *timestamp {
+                    let offset = first_entry_timestamp - *timestamp;
+                    for (timestamp, _) in self.timestamps_with_state_changes.iter_mut() {
+                        *timestamp += offset;
+                    }
+                }
+            }
+        }
+    }
+
     pub fn timestamps_with_state_changes(&self) -> &[(f64, MotorState)] {
         &self.timestamps_with_state_changes
     }

--- a/crates/skytem_logs/src/mbed_motor_control/status.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/status.rs
@@ -100,6 +100,10 @@ impl Plotable for StatusLog {
     fn first_timestamp(&self) -> chrono::DateTime<chrono::Utc> {
         chrono::DateTime::default()
     }
+
+    fn unique_name(&self) -> &str {
+        "Mbed Status log 2024"
+    }
 }
 
 impl StatusLog {

--- a/crates/skytem_logs/src/mbed_motor_control/status.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/status.rs
@@ -109,12 +109,13 @@ impl Plotable for StatusLog {
 impl StatusLog {
     /// If we don't match up with other plot points it is because the date was offset so we need to apply the offset here as well
     pub fn update_timestamp_with_state_changes(&mut self) {
-        if let Some((timestamp, _)) = self.timestamps_with_state_changes.first_mut() {
+        if let Some((first_st_change_timestamp, _)) = self.timestamps_with_state_changes.first_mut()
+        {
             if let Some(first_entry) = self.entries.first() {
                 let first_entry_timestamp = first_entry.timestamp_ns();
-                if first_entry_timestamp != *timestamp {
-                    let offset = first_entry_timestamp - *timestamp;
-                    for (timestamp, _) in self.timestamps_with_state_changes.iter_mut() {
+                if first_entry_timestamp != *first_st_change_timestamp {
+                    let offset = first_entry_timestamp - *first_st_change_timestamp;
+                    for (timestamp, _) in &mut self.timestamps_with_state_changes {
                         *timestamp += offset;
                     }
                 }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -9,7 +9,7 @@ use skytem_logs::{
 use crate::app::PlayBackButtonEvent;
 use axis_config::{AxisConfig, PlotType};
 use egui::Response;
-use egui_plot::{AxisHints, HPlacement, Legend, Plot, PlotPoint, Text};
+use egui_plot::{AxisHints, HPlacement, Legend, Plot};
 use log_if::{util::ExpectedPlotRange, Plotable, RawPlot};
 use play_state::{playback_update_plot, PlayState};
 use plot_visibility_config::PlotVisibilityConfig;
@@ -269,14 +269,6 @@ impl LogPlot {
             if display_percentage_plot {
                 _ = percentage_plot.show(ui, |percentage_plot_ui| {
                     Self::handle_plot(percentage_plot_ui, |arg_plot_ui| {
-                        for status_log in status_logs {
-                            for (ts, st_change) in status_log.timestamps_with_state_changes() {
-                                arg_plot_ui.text(Text::new(
-                                    PlotPoint::new(*ts, ((*st_change as u8) as f64) / 10.0),
-                                    st_change.to_string(),
-                                ));
-                            }
-                        }
                         plot_util::plot_lines(arg_plot_ui, percentage_plots, *line_width);
                         playback_update_plot(timer, arg_plot_ui, is_reset_pressed);
                         axis_config.handle_y_axis_lock(
@@ -312,14 +304,6 @@ impl LogPlot {
                     Self::handle_plot(thousands_plot_ui, |arg_plot_ui| {
                         plot_util::plot_lines(arg_plot_ui, to_thousands_plots, *line_width);
 
-                        for status_log in status_logs {
-                            for (ts, st_change) in status_log.timestamps_with_state_changes() {
-                                arg_plot_ui.text(Text::new(
-                                    PlotPoint::new(*ts, (*st_change as u8) as f64),
-                                    st_change.to_string(),
-                                ));
-                            }
-                        }
                         axis_config.handle_y_axis_lock(
                             arg_plot_ui,
                             PlotType::Thousands,

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use plot_util::PlotWithName;
 use serde::{Deserialize, Serialize};
 use skytem_logs::{
@@ -29,6 +30,7 @@ pub struct LogPlot {
     to_hundreds_plots: Vec<PlotWithName>,
     to_thousands_plots: Vec<PlotWithName>,
     plot_visibility: PlotVisibilityConfig,
+    log_start_dates: Vec<(String, DateTime<Utc>)>,
 }
 
 impl Default for LogPlot {
@@ -42,6 +44,7 @@ impl Default for LogPlot {
             to_hundreds_plots: vec![],
             to_thousands_plots: vec![],
             plot_visibility: PlotVisibilityConfig::default(),
+            log_start_dates: vec![],
         }
     }
 }
@@ -72,6 +75,7 @@ impl LogPlot {
             to_hundreds_plots,
             to_thousands_plots,
             plot_visibility,
+            log_start_dates,
         } = self;
 
         let mut playback_button_event = None;
@@ -83,6 +87,7 @@ impl LogPlot {
             line_width,
             axis_config,
             plot_visibility,
+            log_start_dates,
         );
         if let Some(e) = playback_button_event {
             play_state.handle_playback_button_press(e);
@@ -93,6 +98,13 @@ impl LogPlot {
 
         gui.vertical(|ui| {
             for (idx, pid_log) in pid_logs.iter().enumerate() {
+                let log_id = format!("#{} {}", idx + 1, pid_log.unique_name());
+                if !log_start_dates
+                    .iter()
+                    .any(|(element_log_id, _)| *element_log_id == log_id)
+                {
+                    log_start_dates.push((log_id, pid_log.first_timestamp()));
+                }
                 for raw_plot in pid_log.raw_plots() {
                     let plot_name = format!("{} #{}", raw_plot.name(), idx + 1);
 
@@ -119,6 +131,13 @@ impl LogPlot {
                 }
             }
             for (idx, status_log) in status_logs.iter().enumerate() {
+                let log_id = format!("#{} {}", idx + 1, status_log.unique_name());
+                if !log_start_dates
+                    .iter()
+                    .any(|(element_log_id, _)| *element_log_id == log_id)
+                {
+                    log_start_dates.push((log_id, status_log.first_timestamp()));
+                }
                 for raw_plot in status_log.raw_plots() {
                     let plot_name = format!("{} #{}", raw_plot.name(), idx + 1);
                     match raw_plot.expected_range() {
@@ -144,6 +163,13 @@ impl LogPlot {
                 }
             }
             for (idx, gen_log) in generator_logs.iter().enumerate() {
+                let log_id = format!("#{} {}", idx + 1, gen_log.unique_name());
+                if !log_start_dates
+                    .iter()
+                    .any(|(element_log_id, _)| *element_log_id == log_id)
+                {
+                    log_start_dates.push((log_id, gen_log.first_timestamp()));
+                }
                 for raw_plot in gen_log.raw_plots() {
                     let plot_name = format!("{}, #{}", raw_plot.name(), idx + 1);
                     match raw_plot.expected_range() {

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -355,9 +355,9 @@ where
 }
 
 fn update_plot_dates(
-    percentage_plots: &mut Vec<PlotWithName>,
-    to_hundreds_plots: &mut Vec<PlotWithName>,
-    to_thousands_plots: &mut Vec<PlotWithName>,
+    percentage_plots: &mut [PlotWithName],
+    to_hundreds_plots: &mut [PlotWithName],
+    to_thousands_plots: &mut [PlotWithName],
     settings: &mut LogStartDateSettings,
 ) {
     if settings.date_changed {

--- a/src/plot/date_settings.rs
+++ b/src/plot/date_settings.rs
@@ -1,0 +1,73 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use plot_util::PlotWithName;
+use serde::{Deserialize, Serialize};
+
+#[derive(PartialEq, Deserialize, Serialize)]
+pub struct LogStartDateSettings {
+    pub log_id: String,
+    pub original_start_date: DateTime<Utc>,
+    pub start_date: DateTime<Utc>,
+    pub clicked: bool,
+    pub tmp_date_buf: String,
+    pub err_msg: String,
+    pub new_date_candidate: Option<NaiveDateTime>,
+    pub date_changed: bool,
+}
+
+impl LogStartDateSettings {
+    pub fn new(log_id: String, start_date: DateTime<Utc>) -> Self {
+        Self {
+            log_id,
+            original_start_date: start_date,
+            start_date,
+            clicked: false,
+            tmp_date_buf: String::new(),
+            err_msg: String::new(),
+            new_date_candidate: None,
+            date_changed: false,
+        }
+    }
+}
+
+pub fn update_plot_dates(
+    percentage_plots: &mut [PlotWithName],
+    to_hundreds_plots: &mut [PlotWithName],
+    to_thousands_plots: &mut [PlotWithName],
+    settings: &mut LogStartDateSettings,
+) {
+    if settings.date_changed {
+        apply_offset_to_plots(percentage_plots.iter_mut(), settings);
+        apply_offset_to_plots(to_hundreds_plots.iter_mut(), settings);
+        apply_offset_to_plots(to_thousands_plots.iter_mut(), settings);
+
+        settings.date_changed = false;
+    }
+}
+
+fn offset_plot(plot: &mut PlotWithName, new_start_date: DateTime<Utc>) {
+    if let Some(first_point) = plot.raw_plot.first() {
+        let first_point_date = first_point[0];
+        let new_date_ns = new_start_date
+            .timestamp_nanos_opt()
+            .expect("Nanoseconds overflow") as f64;
+        let offset = new_date_ns - first_point_date;
+
+        log::debug!("Prev time: {first_point_date}, new: {new_date_ns}");
+        log::debug!("Offsetting by: {offset}");
+
+        for point in &mut plot.raw_plot {
+            point[0] += offset;
+        }
+    }
+}
+
+fn apply_offset_to_plots<'a, I>(plots: I, settings: &LogStartDateSettings)
+where
+    I: IntoIterator<Item = &'a mut PlotWithName>,
+{
+    for plot in plots {
+        if plot.log_id == settings.log_id {
+            offset_plot(plot, settings.start_date);
+        }
+    }
+}

--- a/src/plot/plot_ui.rs
+++ b/src/plot/plot_ui.rs
@@ -51,6 +51,7 @@ pub fn show_settings_grid(
             _ = ui.label(" |");
         });
         for settings in log_start_date_settings {
+            arg_ui.end_row();
             let log_name_date = format!("{} [{}]", settings.log_id, settings.start_date);
             if arg_ui.button(log_name_date.clone()).clicked() {
                 settings.clicked = !settings.clicked;
@@ -91,6 +92,7 @@ pub fn show_settings_grid(
                                 if let Some(new_date) = settings.new_date_candidate {
                                     if ui.button("Apply").clicked() {
                                         settings.start_date = new_date.and_utc();
+                                        settings.date_changed = true;
                                         log::info!("New date: {}", settings.start_date);
                                     }
                                 }
@@ -104,6 +106,7 @@ pub fn show_settings_grid(
                     });
             }
         }
+
         arg_ui.end_row();
     });
 }

--- a/src/plot/plot_ui.rs
+++ b/src/plot/plot_ui.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::NaiveDateTime;
 use egui::{Color32, RichText, TextEdit};
 use egui_phosphor::regular;
 
@@ -83,9 +83,7 @@ pub fn show_settings_grid(
                                         settings.new_date_candidate = Some(new_dt);
                                     }
                                     Err(e) => {
-                                        _ = {
-                                            settings.err_msg = format!("⚠ {e} ⚠");
-                                        }
+                                        settings.err_msg = format!("⚠ {e} ⚠");
                                     }
                                 };
                             }

--- a/src/plot/plot_ui.rs
+++ b/src/plot/plot_ui.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use egui::{Color32, RichText};
 use egui_phosphor::regular;
 
@@ -14,6 +15,7 @@ pub fn show_settings_grid(
     line_width: &mut f32,
     axis_cfg: &mut AxisConfig,
     plot_visibility_cfg: &mut PlotVisibilityConfig,
+    log_start_dates: &mut Vec<(String, DateTime<Utc>)>,
 ) {
     _ = egui::Grid::new("settings").show(gui, |arg_ui| {
         _ = arg_ui.label("Line width");
@@ -47,7 +49,9 @@ pub fn show_settings_grid(
             _ = ui.label(RichText::new(play_state.formatted_time()));
             _ = ui.label(" |");
         });
-
+        for (log_name, log_start_dt) in log_start_dates {
+            arg_ui.label(format!("{log_name} [{log_start_dt}]"));
+        }
         arg_ui.end_row();
     });
 }


### PR DESCRIPTION
#### PR Type

- [x] 💰 Feature
- [ ] 🪲 Bug Fix
- [x] 👷‍♀️ Refactor
- [ ] 📖 Documentation Update

#### Description

Adds abillity to adjust timestamps of logs such that plots from different logs can be manually adjusted to better match up.