### PR TITLE
remove T_SHUTDOWN mbed config value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Remove unused `T_SHUTDOWN` config value that was not supposed to be in mbed log v2.
+
 ### Internals
 
 - Refactor to reduce a bunch of duplication and tech debt

--- a/crates/skytem_logs/src/mbed_motor_control/mbed_config.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/mbed_config.rs
@@ -16,8 +16,6 @@ pub struct MbedConfig {
     #[getset(get_copy = "pub")]
     t_standby: u8,
     #[getset(get_copy = "pub")]
-    t_shutdown: u8,
-    #[getset(get_copy = "pub")]
     t_run: u8,
     #[getset(get_copy = "pub")]
     t_fan_on: u8,
@@ -63,7 +61,6 @@ impl MbedConfig {
         let ki = reader.read_f32::<LittleEndian>()?;
         let kd = reader.read_f32::<LittleEndian>()?;
         let t_standby = reader.read_u8()?;
-        let t_shutdown = reader.read_u8()?;
         let t_run = reader.read_u8()?;
         let t_fan_on = reader.read_u8()?;
         let t_fan_off = reader.read_u8()?;
@@ -79,7 +76,6 @@ impl MbedConfig {
             ki,
             kd,
             t_standby,
-            t_shutdown,
             t_run,
             t_fan_on,
             t_fan_off,
@@ -99,7 +95,6 @@ impl MbedConfig {
             ("Ki".to_owned(), self.ki().to_string()),
             ("Kd".to_owned(), self.kd().to_string()),
             ("T_STANDBY".to_owned(), self.t_standby.to_string()),
-            ("T_SHUTDOWN".to_owned(), self.t_shutdown.to_string()),
             ("T_RUN".to_owned(), self.t_run.to_string()),
             ("T_FAN_On".to_owned(), self.t_fan_on.to_string()),
             ("T_FAN_Off".to_owned(), self.t_fan_off.to_string()),

--- a/crates/skytem_logs/src/mbed_motor_control/pid/header/v2.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/pid/header/v2.rs
@@ -203,7 +203,6 @@ mod tests {
         assert_eq!(pid_log_header.mbed_config().ki(), 1.0);
         assert_eq!(pid_log_header.mbed_config().kd(), 0.0);
         assert_eq!(pid_log_header.mbed_config().t_standby(), 50);
-        assert_eq!(pid_log_header.mbed_config().t_shutdown(), 102);
         assert_eq!(pid_log_header.mbed_config().t_run(), 65);
         assert_eq!(pid_log_header.mbed_config().t_fan_on(), 81);
         assert_eq!(pid_log_header.mbed_config().t_fan_off(), 80);

--- a/crates/skytem_logs/src/mbed_motor_control/status/header/v2.rs
+++ b/crates/skytem_logs/src/mbed_motor_control/status/header/v2.rs
@@ -200,7 +200,6 @@ mod tests {
         assert_eq!(status_log_header.mbed_config().ki(), 1.0);
         assert_eq!(status_log_header.mbed_config().kd(), 0.0);
         assert_eq!(status_log_header.mbed_config().t_standby(), 50);
-        assert_eq!(status_log_header.mbed_config().t_shutdown(), 102);
         assert_eq!(status_log_header.mbed_config().t_run(), 65);
         assert_eq!(status_log_header.mbed_config().t_fan_on(), 81);
         assert_eq!(status_log_header.mbed_config().t_fan_off(), 80);


### PR DESCRIPTION
#### PR Type

- [ ] 💰 Feature
- [ ] 🪲 Bug Fix
- [x] 👷‍♀️ Refactor
- [ ] 📖 Documentation Update

#### Description

<!--- Provide a summary of your changes -->
<!--- Link to any related issues this PR resolves -->
<!--- If integration tests have been performed, describe the tests along with their outcomes -->

- [ ] New config test data with the v2 log with the `T_SHUTDOWN` value removed.

#### Checklist

- [x] 🌞 Changelog updated
